### PR TITLE
Included url-api parameter and the value for some portals

### DIFF
--- a/config/instances.json
+++ b/config/instances.json
@@ -3,6 +3,7 @@
         "description": "Austria\u2019s national data portal Offene Daten \u00d6sterreich contains both government data and data harvested from a number of city portals, including the CKAN portals at Linz and Graz.",
         "title": "data.gv.at",
         "url": "http://data.gv.at",
+        "url-api": "http://data.gv.at/katalog",
         "facets": [
             {
                 "value": "Europe",
@@ -143,6 +144,7 @@
         "description": "The US government announced in January 2013 that they were moving to CKAN for their open data catalogue, combining datasets previously published in different places. The relaunch went live in May 2013.",
         "title": "Data.gov",
         "url": "http://data.gov",
+		"url-api": "http://catalog.data.gov",
         "facets": [
             {
                 "value": "Featured",
@@ -202,6 +204,7 @@
         "description": "data.NSW brings together a list of NSW Government datasets available in one searchable website. The NSW Government aims to make data more accessible to the public and to industry to stimulate innovative approaches to service delivery.",
         "title": "data.NSW",
         "url": "http://data.nsw.gov.au",
+        "url-api": "http://data.nsw.gov.au/data",
         "facets": [
             {
                 "value": "Australasia",
@@ -529,6 +532,7 @@
         "description": "The European Union has its own portal for releasing data held by the various bodies of the Union, including Eurostat, the European Statistics Agency.",
         "title": "EU Open Data",
         "url": "http://open-data.europa.eu/",
+        "url-api": "http://open-data.europa.eu/data",
         "facets": [
             {
                 "value": "Europe",
@@ -1808,6 +1812,7 @@
         "description": "Federated systems of data providers releasing data to support exploration for and development of geothermal resources. Academic institutions and government (state and federal) geological surveys are providing data. CKAN is used as an aggregator for metadata from nodes, and we have an installable CKAN/GeoServer stack  to make deploying new nodes as easy as we can. Metadata integration uses OGC CSW and an ISO metadata profile.",
         "title": "National Geothermal Data System",
         "url": "http://geothermaldata.org",
+        "url-api": "http://search.geothermaldata.org",
         "facets": [
             {
                 "value": "Other Organizations",
@@ -2301,6 +2306,7 @@
         "description": "Open Data Portal for Austrian non-governmental data.",
         "title": "OpenDataPortal Austria",
         "url": "https://opendataportal.at",
+		"url-api": "http://data.opendataportal.at",
         "facets": [
             {
                 "value": "Europe",


### PR DESCRIPTION
Many portals have different URLs for web access and API access. Thus, the "url-api" parameter was included to be used in this case.
