### PR TITLE
fix incorrect description of Data.Rio

### DIFF
--- a/config/instances.json
+++ b/config/instances.json
@@ -1418,7 +1418,7 @@
         "id": "dados_rs_gov_br"
     },
     {
-        "description": "Portal for the brazilian state Rio Grande do Sul. Using CKAN 2.2.",
+        "description": "Portal for the brazilian state Rio de Janeiro. Using CKAN 2.2.",
         "title": "Data.Rio",
         "url": "http://data.rio.rj.gov.br/",
         "facets": [


### PR DESCRIPTION
The state name in the description is wrong.
