### PR TITLE
fix the link of Houston Data Portal

### DIFF
--- a/config/instances.json
+++ b/config/instances.json
@@ -846,7 +846,7 @@
     {
         "description": "The Houston Data Portal is a project of Code for Houston, a citizen's initiative of programmers in Houston, Texas, aiming to improve the city.",
         "title": "Houston Data Portal",
-        "url": "http://data.codeforhouston.com/",
+        "url": "http://data.ohouston.org/",
         "facets": [
             {
                 "key": "Region",


### PR DESCRIPTION
The url in the original list has been disabled and this one should be the recent one.
