### PR TITLE
Remove gong.io, close #105

### DIFF
--- a/config/instances.json
+++ b/config/instances.json
@@ -1810,23 +1810,6 @@
         "id": "drdsi_jrc_ec_europa_eu"
     },
     {
-        "description": "Open data initiative and platform for Wollongong and the greater Illawarra region in Australia (about an hour south of Sydney)",
-        "title": "Gong.io",
-        "url": "http://gong.io",
-        "facets": [
-            {
-                "value": "Australasia",
-                "key": "Region"
-            },
-            {
-                "value": "Community",
-                "key": "Type"
-            }
-        ],
-        "location": "Wollongong, Australia",
-        "id": "gong_io"
-    },
-    {
         "description": "OpenDataReno is a place to exchange data and information useful to the residents of the greater Reno/Sparks/Washoe County area.",
         "title": "OpenDataReno",
         "url": "http://opendatareno.org",


### PR DESCRIPTION
gong.io is now a sales site, I can't find any references to a Wollongong open data site anymore.
